### PR TITLE
Set certs to be copied on deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,7 +14,7 @@ sudo cp arrow/arrowKtVersion try.arrow-kt.web
 
 sudo cp deploy/.secret try.arrow-kt.web
 
-sudo cp cert/* try.arrow-kt.web/docker/frontend/conf
+sudo cp cert/* -r try.arrow-kt.web/docker/frontend/conf
 
 sudo cp server.xml try.arrow-kt.web/docker/frontend/conf
 


### PR DESCRIPTION
* Set certs to be copied on deploy.
* The lack of `r` option on `cp` command was making it impossible to find the files.